### PR TITLE
Add security suite CLI and user guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,9 +136,9 @@ full: $(LIB_STATIC) $(CHARM_BIN) $(BENCH_BIN)
 
 # Build security suite
 security_suite: $(SECURITY_SUITE_OBJECTS) $(BUILD_DIR)/avx2_detect.o $(BUILD_DIR)/ece_core.o $(BUILD_DIR)/ece_digest.o $(BUILD_DIR)/entropy_bus.o $(BUILD_DIR)/system_entropy.o
-	@echo "Building CHARM Security Suite..."
+	@echo "Building CHARM Security Suite CLI..."
 	$(CC) $(CFLAGS) -o $(BUILD_DIR)/charm_security_suite \
-		$(SRC_DIR)/main.c \
+		$(SRC_DIR)/security_suite_cli.c \
 		$(SECURITY_SUITE_OBJECTS) \
 		$(BUILD_DIR)/avx2_detect.o $(BUILD_DIR)/ece_core.o $(BUILD_DIR)/ece_digest.o \
 		$(BUILD_DIR)/entropy_bus.o $(BUILD_DIR)/system_entropy.o \

--- a/documents/SECURITY_SUITE_CLI_GUIDE.md
+++ b/documents/SECURITY_SUITE_CLI_GUIDE.md
@@ -1,0 +1,55 @@
+# CHARM Security Suite CLI Guide
+
+The CHARM Security Suite ships with a dedicated command line interface that
+provides convenient access to core platform services such as capability
+inspection, health monitoring, incident reporting and SBOM generation.
+
+## Building
+
+```bash
+make security_suite
+```
+
+This command builds the `charm_security_suite` executable in the `build/`
+directory along with all required security suite components.
+
+## Usage
+
+```bash
+charm_security_suite [OPTIONS]
+```
+
+### Options
+
+- `--status` – display current suite status including security level and
+  entropy quality.
+- `--capabilities` – list enabled security capabilities as a bitmask.
+- `--health` – run the comprehensive security health check and list any
+  discovered issues.
+- `--sbom FILE` – generate a software bill of materials in JSON format and
+  write it to `FILE`.
+- `--report TYPE:DESC` – report a security incident. `TYPE` is one of
+  `AUTH_FAILURE`, `AUTHZ_VIOLATION`, `CRYPTO_FAILURE`, `KEY_COMPROMISE`,
+  `AUDIT_TAMPERING`, `CONFIG_VIOLATION`, `ENTROPY_DEGRADATION` or
+  `UNKNOWN_THREAT`. `DESC` is a short description of the incident.
+- `--version` – show the security suite version.
+- `--help` – display built‑in help with all options and examples.
+
+### Examples
+
+```bash
+# Show current status and capabilities
+charm_security_suite --status --capabilities
+
+# Perform a health check
+charm_security_suite --health
+
+# Report an authentication failure incident
+charm_security_suite --report AUTH_FAILURE:"Invalid password for admin"
+
+# Generate an SBOM
+charm_security_suite --sbom sbom.json
+```
+
+The CLI initializes the security suite automatically and shuts it down on
+exit. Multiple options can be combined in a single invocation.

--- a/src/security_suite_cli.c
+++ b/src/security_suite_cli.c
@@ -1,0 +1,189 @@
+/**
+ * @file security_suite_cli.c
+ * @brief Command line interface for the CHARM Security Suite
+ *
+ * This CLI provides convenient access to core CHARM Security Suite
+ * functionality including status reporting, capability inspection,
+ * health checks, incident reporting and SBOM generation.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <getopt.h>
+#include <stdint.h>
+
+#include "charm_security_suite.h"
+
+/* Print usage information */
+static void print_help(void) {
+    printf("CHARM Security Suite CLI\n\n");
+    printf("Usage: charm_security_suite [OPTIONS]\n\n");
+    printf("Options:\n");
+    printf("  --status                Display current security suite status\n");
+    printf("  --capabilities          List enabled security capabilities\n");
+    printf("  --health                Run comprehensive health check\n");
+    printf("  --sbom FILE             Generate SBOM in JSON format and write to FILE\n");
+    printf("  --report TYPE:DESC      Report security incident with type and description\n");
+    printf("  --version               Show security suite version\n");
+    printf("  --help                  Show this help message\n\n");
+    printf("Examples:\n");
+    printf("  charm_security_suite --status\n");
+    printf("  charm_security_suite --capabilities --version\n");
+    printf("  charm_security_suite --health\n");
+    printf("  charm_security_suite --report AUTH_FAILURE:\"Invalid password\"\n");
+    printf("  charm_security_suite --sbom sbom.json\n");
+}
+
+/* Map string to incident type enum */
+static charm_incident_type_t parse_incident_type(const char* type) {
+    if (strcmp(type, "AUTH_FAILURE") == 0) {
+        return CHARM_INCIDENT_AUTHENTICATION_FAILURE;
+    } else if (strcmp(type, "AUTHZ_VIOLATION") == 0) {
+        return CHARM_INCIDENT_AUTHORIZATION_VIOLATION;
+    } else if (strcmp(type, "CRYPTO_FAILURE") == 0) {
+        return CHARM_INCIDENT_CRYPTO_FAILURE;
+    } else if (strcmp(type, "KEY_COMPROMISE") == 0) {
+        return CHARM_INCIDENT_KEY_COMPROMISE;
+    } else if (strcmp(type, "AUDIT_TAMPERING") == 0) {
+        return CHARM_INCIDENT_AUDIT_TAMPERING;
+    } else if (strcmp(type, "CONFIG_VIOLATION") == 0) {
+        return CHARM_INCIDENT_CONFIG_VIOLATION;
+    } else if (strcmp(type, "ENTROPY_DEGRADATION") == 0) {
+        return CHARM_INCIDENT_ENTROPY_DEGRADATION;
+    }
+    return CHARM_INCIDENT_UNKNOWN_THREAT;
+}
+
+int main(int argc, char* argv[]) {
+    int opt;
+    int option_index = 0;
+    bool show_status = false;
+    bool show_caps = false;
+    bool show_health = false;
+    bool show_version = false;
+    char* sbom_file = NULL;
+    char* report_arg = NULL;
+
+    static struct option long_options[] = {
+        {"status", no_argument, 0, 's'},
+        {"capabilities", no_argument, 0, 'c'},
+        {"health", no_argument, 0, 'h'},
+        {"sbom", required_argument, 0, 'b'},
+        {"report", required_argument, 0, 'r'},
+        {"version", no_argument, 0, 'v'},
+        {"help", no_argument, 0, 'H'},
+        {0, 0, 0, 0}
+    };
+
+    if (argc == 1) {
+        print_help();
+        return 0;
+    }
+
+    while ((opt = getopt_long(argc, argv, "schb:r:vH", long_options, &option_index)) != -1) {
+        switch (opt) {
+            case 's':
+                show_status = true;
+                break;
+            case 'c':
+                show_caps = true;
+                break;
+            case 'h':
+                show_health = true;
+                break;
+            case 'b':
+                sbom_file = optarg;
+                break;
+            case 'r':
+                report_arg = optarg;
+                break;
+            case 'v':
+                show_version = true;
+                break;
+            case 'H':
+                print_help();
+                return 0;
+            default:
+                print_help();
+                return 1;
+        }
+    }
+
+    if (charm_security_suite_init(NULL) != 0) {
+        fprintf(stderr, "Failed to initialize CHARM Security Suite\n");
+        return 1;
+    }
+
+    int exit_code = 0;
+
+    if (show_version) {
+        printf("Version: %s\n", charm_security_suite_get_version());
+    }
+
+    if (show_caps) {
+        uint32_t caps;
+        if (charm_security_suite_get_capabilities(&caps) == 0) {
+            printf("Enabled capabilities: 0x%08X\n", caps);
+        } else {
+            fprintf(stderr, "Error retrieving capabilities\n");
+            exit_code = 1;
+        }
+    }
+
+    if (show_status) {
+        charm_security_suite_status_t status;
+        if (charm_security_suite_get_status(&status) == 0) {
+            printf("Initialized: %s\n", status.initialized ? "yes" : "no");
+            printf("Security level: %d\n", status.current_security_level);
+            printf("Entropy quality: %.4f\n", status.entropy_quality);
+            printf("Incidents recorded: %lu\n", (unsigned long)status.total_audit_events);
+        } else {
+            fprintf(stderr, "Error retrieving status\n");
+            exit_code = 1;
+        }
+    }
+
+    if (show_health) {
+        char issues[10][256];
+        size_t issue_count = 0;
+        int score = charm_security_suite_health_check(issues, 10, &issue_count);
+        printf("Health score: %d/100\n", score);
+        for (size_t i = 0; i < issue_count; i++) {
+            printf(" - %s\n", issues[i]);
+        }
+    }
+
+    if (sbom_file) {
+        if (charm_security_suite_generate_sbom(sbom_file, "json") == 0) {
+            printf("SBOM written to %s\n", sbom_file);
+        } else {
+            fprintf(stderr, "Failed to generate SBOM\n");
+            exit_code = 1;
+        }
+    }
+
+    if (report_arg) {
+        char* colon = strchr(report_arg, ':');
+        if (!colon) {
+            fprintf(stderr, "Invalid --report argument. Use TYPE:DESC\n");
+            exit_code = 1;
+        } else {
+            *colon = '\0';
+            const char* type_str = report_arg;
+            const char* desc = colon + 1;
+            charm_incident_type_t type = parse_incident_type(type_str);
+            uint64_t id = 0;
+            if (charm_security_suite_report_incident(type, "cli", desc, NULL, 5, &id) == 0) {
+                printf("Incident reported with ID %lu\n", id);
+            } else {
+                fprintf(stderr, "Failed to report incident\n");
+                exit_code = 1;
+            }
+        }
+    }
+
+    charm_security_suite_shutdown();
+    return exit_code;
+}


### PR DESCRIPTION
## Summary
- implement dedicated `charm_security_suite` CLI with status, capabilities, health, incident reporting and SBOM generation features
- document CLI usage in `SECURITY_SUITE_CLI_GUIDE.md`
- update build system to compile new CLI

## Testing
- `make security_suite` *(fails: ECE_STATE_SIZE undeclared in ece_core.c)*
- `make test_security_suite_minimal` *(fails: ECE_STATE_SIZE undeclared in ece_core.c)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b8209200832288455bdcffd29108